### PR TITLE
Add auto acquisition of workspace URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,6 @@ pip install merida
 * In `visualization_tool.py`:
   * Change the `lightcurve_name` variable to the name of the light curve you want to visualize.
   * Define where your data is `data_path ='data/positive'`
-  * If you want to use data from the NEXSci archive, you might have to change line 19 on `lightcurves_cls` in the LightCurvesNExSciURL class.
-    
-    Note that mine has: 
-    ```
-    self.url_main_path = 'https://exoplanetarchive.ipac.caltech.edu/workspace/TMP_dk5Wxv_13874/MOA/tab1/data/' 
-    ```
-    Unfortunately, this is a temporary link. You will have to open https://exoplanetarchive.ipac.caltech.edu/cgi-bin/MOA/nph-firefly?MOA and click to download a lightcurve. I tried a couple of times and got the same temp url address with `TMP_dk5Wxv_13874`. If you get something different, you have to modify this line of code to one equivalent. 
 
 After done that, you just have to run the following command in the terminal:
 ```
@@ -31,12 +24,6 @@ bokeh serve --show visualization_tool.py
 
 ---
 ### To locally download a single MOA9yr lightcurve from the NExSci archive:
-* Unfortunately, this is based on a temporary link. You will have to open https://exoplanetarchive.ipac.caltech.edu/cgi-bin/MOA/nph-firefly?MOA and click to download a lightcurve to "activate a temp link". I tried a couple of times and got the same temp url address with `TMP_dk5Wxv_13874`. If you get something different:
-  * Change line 19 on `lightcurves_cls` in the LightCurvesNExSciURL class.
-      Note that mine has: 
-      ```
-      self.url_main_path = 'https://exoplanetarchive.ipac.caltech.edu/workspace/TMP_dk5Wxv_13874/MOA/tab1/data/' 
-      ``` 
 * In `lightcurve_downloader.py`:
   * Change the `lightcurve_name` variable to the name of the light curve you want to download.
   * You can change the path by adding the variable `path_to_save_ ='[the_path_you_want_]/'`
@@ -55,12 +42,6 @@ python lightcurve_downloader.py
   df_temp = df_total[df_total['ROW_NUM'] > (n-1)*160604]
   df = df_temp[df_temp['ROW_NUM'] <= n*160604]
   ```
-* Unfortunately, this is based on a temporary link. You will have to open https://exoplanetarchive.ipac.caltech.edu/cgi-bin/MOA/nph-firefly?MOA and click to download a lightcurve to "activate a temp link". aI tried a couple of times and got the same temp url address with `TMP_dk5Wxv_13874`. If you get something different:
-  * Change line 19 on `lightcurves_cls` in the LightCurvesNExSciURL class.
-      Note that mine has: 
-      ```
-      self.url_main_path = 'https://exoplanetarchive.ipac.caltech.edu/workspace/TMP_dk5Wxv_13874/MOA/tab1/data/' 
-      ``` 
 * In `all_lightcurves_downloader.py`:
   * You can change the path by changing the variable `path_to_save_ ='[the_path_you_want_]/'`
   * You can also change the extension `lightcurve_extension_='.[extension]'`. Only `feather` and `CSV` supported for now. 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tqdm==4.66.3
 requests==2.32.0
 lxml==4.9.3
 html5lib==1.1
+beautifulsoup4==4.13.3

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,5 @@ setup(name='merida',
                         "tqdm==4.66.3",
                         "requests==2.32.0",
                         "lxml==4.9.3",
-                        "html5lib==1.1"])
+                        "html5lib==1.1",
+                        "beautifulsoup4==4.13.3",])


### PR DESCRIPTION
Automatically gets the IPAC MOA archive temporary workspace URL so that the user does not need to manually enter one.